### PR TITLE
Syntax error fix - Fix incorrectly commented code (should be "--")

### DIFF
--- a/mods/tgns/output/lua/shine/extensions/autoexec/server.lua
+++ b/mods/tgns/output/lua/shine/extensions/autoexec/server.lua
@@ -8,29 +8,29 @@ local autoExecsCacheWasPreloaded = false
 
 local md = TGNSMessageDisplayer.Create("AUTOFPS")
 
-//local function ShowCurrentCommands(client)
-//	local steamId = TGNS.GetClientSteamId(client)
-//	local data = pdr:Load(steamId)
-//	md:ToClientConsole(client, "")
-//	md:ToClientConsole(client, "Your current commands:")
-//	TGNS.DoFor(data.commands, function(c)
-//		md:ToClientConsole(client, string.format("    %s", c))
-//	end)
-//	md:ToClientConsole(client, "")
-//	md:ToClientConsole(client, " * Re-specifying any existing command will remove it from the list.")
-//	md:ToClientConsole(client, "")
-//end
-//
-//local function ShowUsage(client)
-//	md:ToClientConsole(client, "")
-//	md:ToClientConsole(client, " Usage:")
-//	md:ToClientConsole(client, "     sv_autoexec <command>")
-//	md:ToClientConsole(client, " Notes:")
-//	md:ToClientConsole(client, " * Configured commands execute only when you connect as a Supporting Member")
-//	md:ToClientConsole(client, "")
-//	ShowCurrentCommands(client)
-//	md:ToClientConsole(client, "")
-//end
+--//local function ShowCurrentCommands(client)
+--//	local steamId = TGNS.GetClientSteamId(client)
+--//	local data = pdr:Load(steamId)
+--//	md:ToClientConsole(client, "")
+--//	md:ToClientConsole(client, "Your current commands:")
+--//	TGNS.DoFor(data.commands, function(c)
+--//		md:ToClientConsole(client, string.format("    %s", c))
+--//	end)
+--//	md:ToClientConsole(client, "")
+--//	md:ToClientConsole(client, " * Re-specifying any existing command will remove it from the list.")
+--//	md:ToClientConsole(client, "")
+--//end
+--//
+--//local function ShowUsage(client)
+--//	md:ToClientConsole(client, "")
+--//	md:ToClientConsole(client, " Usage:")
+--//	md:ToClientConsole(client, "     sv_autoexec <command>")
+--//	md:ToClientConsole(client, " Notes:")
+--//	md:ToClientConsole(client, " * Configured commands execute only when you connect as a Supporting Member")
+--//	md:ToClientConsole(client, "")
+--//	ShowCurrentCommands(client)
+--//	md:ToClientConsole(client, "")
+--//end
 
 function Plugin:ClientConnect(client)
 	local steamId = TGNS.GetClientSteamId(client)

--- a/mods/tgns/output/lua/shine/extensions/captains/captains.lua
+++ b/mods/tgns/output/lua/shine/extensions/captains/captains.lua
@@ -1086,7 +1086,7 @@ if Server or Client then
 		local highVolumeMessagesLastShownTime
 		local bannerDisplayed
 		local showRemainingTimer
-		//local lastOptInAttemptWhen = {}
+--		//local lastOptInAttemptWhen = {}
 		local OPT_IN_THROTTLE_IN_SECONDS = 3
 		local allPlayersWereArtificiallyForcedToReadyRoom
 		local setSpawnsSummaryText
@@ -1361,7 +1361,7 @@ if Server or Client then
 			whenToAllowTeamJoins = TGNS.GetSecondsSinceMapLoaded() + 10
 			votesAllowedUntil = nil
 			TGNS.ScheduleAction(1, showPickables)
-			//Shine.Plugins.afkkick.Config.KickTime = 20
+--			//Shine.Plugins.afkkick.Config.KickTime = 20
 			TGNS.DoFor(TGNS.GetClientList(), function(c)
 				Shine.ScreenText.End(93, c)
 				Shine.ScreenText.End(94, c)
@@ -1507,13 +1507,13 @@ if Server or Client then
 		local function addReadyPlayerClient(client)
 			if votesAllowedUntil == nil then
 				votesAllowedUntil = TGNS.GetSecondsSinceMapLoaded() + OPTIN_VOTE_DURATION + 2
-				// TGNS.DoFor(readyPlayerClients, function(c)
-				// 	if Shine:IsValidClient(c) then
-				// 		if not captainsModeEnabled then
-				// 			md:ToPlayerNotifyInfo(TGNS.GetPlayer(c), "You are now opted-in to play a Captains game.")
-				// 		end
-				// 	end
-				// end)
+--				// TGNS.DoFor(readyPlayerClients, function(c)
+--				// 	if Shine:IsValidClient(c) then
+--				// 		if not captainsModeEnabled then
+--				// 			md:ToPlayerNotifyInfo(TGNS.GetPlayer(c), "You are now opted-in to play a Captains game.")
+--				// 		end
+--				// 	end
+--				// end)
 				TGNS.ScheduleAction(1, announceTimeRemaining)
 			elseif votesAllowedUntil == math.huge and not infiniteTimeRemainingDisplayStarted then
 				infiniteTimeRemainingDisplayStarted = true
@@ -1585,21 +1585,21 @@ if Server or Client then
 			updateCaptainsReadyProgress(client)
 		end
 
-		//function swapTeamsAfterDelay(delayInSeconds)
-		//	local originalPlayerTeamNumbers = {}
-		//	TGNS.DoFor(TGNS.GetPlayerList(), function(p)
-		//		if TGNS.PlayerIsOnPlayingTeam(p) then
-		//			originalPlayerTeamNumbers[p] = TGNS.GetPlayerTeamNumber(p)
-		//		end
-		//	end)
-		//	TGNS.ScheduleAction(delayInSeconds, function()
-		//		TGNS.DoForPairs(originalPlayerTeamNumbers, function(player, teamNumber)
-		//			local otherTeamNumber = teamNumber == 1 and 2 or 1
-		//			TGNS.SendToTeam(player, otherTeamNumber, true)
-		//		end)
-		//		md:ToAllNotifyInfo("Teams have been swapped!")
-		//	end)
-		//end
+--		//function swapTeamsAfterDelay(delayInSeconds)
+--		//	local originalPlayerTeamNumbers = {}
+--		//	TGNS.DoFor(TGNS.GetPlayerList(), function(p)
+--		//		if TGNS.PlayerIsOnPlayingTeam(p) then
+--		//			originalPlayerTeamNumbers[p] = TGNS.GetPlayerTeamNumber(p)
+--		//		end
+--		//	end)
+--		//	TGNS.ScheduleAction(delayInSeconds, function()
+--		//		TGNS.DoForPairs(originalPlayerTeamNumbers, function(player, teamNumber)
+--		//			local otherTeamNumber = teamNumber == 1 and 2 or 1
+--		//			TGNS.SendToTeam(player, otherTeamNumber, true)
+--		//		end)
+--		//		md:ToAllNotifyInfo("Teams have been swapped!")
+--		//	end)
+--		//end
 
 		function getCaptainsGameStateDescription()
 			local result = ""
@@ -2030,8 +2030,8 @@ if Server or Client then
 					end
 				end
 
-				// if TGNS.GetSecondsSinceMapLoaded() - (lastOptInAttemptWhen[client] or 0) < OPT_IN_THROTTLE_IN_SECONDS then
-				// 	md:ToPlayerNotifyError(player, string.format("Every opt-in attempt (including this one) resets a %s-second cooldown.", OPT_IN_THROTTLE_IN_SECONDS))
+--				// if TGNS.GetSecondsSinceMapLoaded() - (lastOptInAttemptWhen[client] or 0) < OPT_IN_THROTTLE_IN_SECONDS then
+--				// 	md:ToPlayerNotifyError(player, string.format("Every opt-in attempt (including this one) resets a %s-second cooldown.", OPT_IN_THROTTLE_IN_SECONDS))
 				if TGNS.IsPlayerSpectator(player) then
 					md:ToPlayerNotifyError(player, "You may not use this command as a spectator.")
 				elseif (not rolandHasBeenUsed) and (not TGNS.PlayerIsOnPlayingTeam(player)) and not captainsModeEnabled then
@@ -2065,17 +2065,17 @@ if Server or Client then
 						end
 					end
 				end
-				// lastOptInAttemptWhen[client] = TGNS.GetSecondsSinceMapLoaded()
-				// if not TGNS.IsClientAdmin(client) and not TGNS.Has(readyPlayerClients, client) then
-				// 	TGNS.ScheduleAction(3.5, function()
-				// 		if Shine:IsValidClient(client) then
-				// 			TGNS.AddTempGroup(client, "iwantcaptainscommand_group")
-				// 			md:ToPlayerNotifyInfo(TGNS.GetPlayer(client), "... sh_iwantcaptains restored.")
-				// 		end
-				// 	end)
-				// 	TGNS.RemoveTempGroup(client, "iwantcaptainscommand_group")
-				// 	md:ToPlayerNotifyInfo(player, "sh_iwantcaptains 4-second cooldown started...")
-				// end
+--				// lastOptInAttemptWhen[client] = TGNS.GetSecondsSinceMapLoaded()
+--				// if not TGNS.IsClientAdmin(client) and not TGNS.Has(readyPlayerClients, client) then
+--				// 	TGNS.ScheduleAction(3.5, function()
+--				// 		if Shine:IsValidClient(client) then
+--				// 			TGNS.AddTempGroup(client, "iwantcaptainscommand_group")
+--				// 			md:ToPlayerNotifyInfo(TGNS.GetPlayer(client), "... sh_iwantcaptains restored.")
+--				// 		end
+--				// 	end)
+--				// 	TGNS.RemoveTempGroup(client, "iwantcaptainscommand_group")
+--				// 	md:ToPlayerNotifyInfo(player, "sh_iwantcaptains 4-second cooldown started...")
+--				// end
 			end)
 			wantCaptainsCommand:Help(string.format("Tell the server you want to play a Captains Game (cooldown: %s seconds).", OPT_IN_THROTTLE_IN_SECONDS))
 

--- a/mods/tgns/output/lua/shine/extensions/chatchannels.lua
+++ b/mods/tgns/output/lua/shine/extensions/chatchannels.lua
@@ -37,7 +37,7 @@ local function ProcessChatCommand(sourceClient, channel, command, message)
 		else
 			md:ToPlayerNotifyError(sourcePlayer, "Admin usage: @<name> <message>, if name is blank only admins are messaged")
 		end
-	// Non-admins will send the message to all admins
+--	// Non-admins will send the message to all admins
 	else
 		local chatMessage = GetChatMessage(message)
 		if chatMessage then

--- a/mods/tgns/output/lua/shine/extensions/notifyadminonmuteplayer.lua
+++ b/mods/tgns/output/lua/shine/extensions/notifyadminonmuteplayer.lua
@@ -56,23 +56,23 @@ local function TellAdminsAboutPlayerMutes()
 	end
 end
 
-//local function ListMutes(client)
-//	// build look up table for player names by clientindex
-//	playerNames = {}
-//
-//	ServerAdminPrint(client, "Player Mutes:")
-//	for _, player in pairs(TGNS.GetPlayerList()) do
-//		playerNames[player:GetClientIndex()] = player:GetName()
-//	end
-//	for _, player in pairs(TGNS.GetPlayerList()) do
-//		for clientIndex, name in pairs(playerNames) do
-//			if player:GetClientMuted(clientIndex) then
-//				ServerAdminPrint(client, player:GetName() .. " : " .. name)
-//			end
-//		end
-//	end
-//end
-//TGNS.RegisterCommandHook("Console_sv_mutes", ListMutes, help)
+--//local function ListMutes(client)
+--//	// build look up table for player names by clientindex
+--//	playerNames = {}
+--//
+--//	ServerAdminPrint(client, "Player Mutes:")
+--//	for _, player in pairs(TGNS.GetPlayerList()) do
+--//		playerNames[player:GetClientIndex()] = player:GetName()
+--//	end
+--//	for _, player in pairs(TGNS.GetPlayerList()) do
+--//		for clientIndex, name in pairs(playerNames) do
+--//			if player:GetClientMuted(clientIndex) then
+--//				ServerAdminPrint(client, player:GetName() .. " : " .. name)
+--//			end
+--//		end
+--//	end
+--//end
+--//TGNS.RegisterCommandHook("Console_sv_mutes", ListMutes, help)
 
 local Plugin = {}
 

--- a/mods/tgns/output/lua/shine/extensions/permissions.lua
+++ b/mods/tgns/output/lua/shine/extensions/permissions.lua
@@ -81,16 +81,16 @@ function Plugin:Initialise()
     return true
 end
 
-/*function Plugin:IsSteamIdInGroup(steamId, groupName)
-	local result = false
-	TGNS.DoForPairs(dakData.users, function(userKey, userData)
-		if userData.id == steamId and TGNS.Any(userData.groups, function(x) return x == groupName end) then
-			result = true
-		end
-		return result
-	end)
-	return result
-end*/
+--/*function Plugin:IsSteamIdInGroup(steamId, groupName)
+--	local result = false
+--	TGNS.DoForPairs(dakData.users, function(userKey, userData)
+--		if userData.id == steamId and TGNS.Any(userData.groups, function(x) return x == groupName end) then
+--			result = true
+--		end
+--		return result
+--	end)
+--	return result
+--end*/
 
 -- Fix start - Fix with cache
 function Plugin:IsSteamIdInGroup(steamId, groupName)

--- a/mods/tgns/output/lua/shine/extensions/scoreboard/client.lua
+++ b/mods/tgns/output/lua/shine/extensions/scoreboard/client.lua
@@ -1279,7 +1279,7 @@ function Plugin:Initialise()
 			if Client.GetScreenHeight() >= 1080 then
 				local numAliens = 0
 				local allPlayers = ScoreboardUI_GetAllScores()
-			    // How many items per player.
+--			    // How many items per player.
 			    for i = 1, #allPlayers do
 			        if allPlayers[i].EntityTeamNumber == kAlienTeamType then
 			        	numAliens = numAliens + 1

--- a/mods/tgns/output/lua/shine/extensions/stagedteamjoins.lua
+++ b/mods/tgns/output/lua/shine/extensions/stagedteamjoins.lua
@@ -1,17 +1,17 @@
-//local FIRSTCLIENT_TIME_BEFORE_ALLJOIN = 45
+--//local FIRSTCLIENT_TIME_BEFORE_ALLJOIN = 45
 local GAMEEND_TIME_BEFORE_ALLJOIN = TGNS.ENDGAME_TIME_TO_READYROOM + 5
 local allMayJoinAt = 0 // Shared.GetSystemTime() + FIRSTCLIENT_TIME_BEFORE_ALLJOIN
-//local firstClientProcessed = false
+--//local firstClientProcessed = false
 local md = TGNSMessageDisplayer.Create()
 
 local Plugin = {}
 
-//function Plugin:ClientConnect(client)
-//	if not firstClientProcessed then
-//		allMayJoinAt = Shared.GetTime() + FIRSTCLIENT_TIME_BEFORE_ALLJOIN
-//		firstClientProcessed = true
-//	end
-//end
+--//function Plugin:ClientConnect(client)
+--//	if not firstClientProcessed then
+--//		allMayJoinAt = Shared.GetTime() + FIRSTCLIENT_TIME_BEFORE_ALLJOIN
+--//		firstClientProcessed = true
+--//	end
+--//end
 
 function atLeastOneSupportingMemberIsPresent()
 	local result = TGNS.Any(TGNS.GetReadyRoomClients(TGNS.GetPlayerList()), TGNS.IsClientSM)

--- a/mods/tgns/output/lua/tgns/server/TGNSNs2StatsProxy.lua
+++ b/mods/tgns/output/lua/tgns/server/TGNSNs2StatsProxy.lua
@@ -41,8 +41,8 @@ TGNSNs2StatsProxy.GetPlayerRecord = function(steamId)
 	local result = {}
 	local decodedResponseForPlayer = decodedResponses[steamId]
 	result.HasData = decodedResponseForPlayer ~= nil
-	result.HasData = result.HasData and TGNS.IsNumberWithNonZeroPositiveValue(decodedResponseForPlayer.score) // discard found records lacking score
-	result.HasData = result.HasData and TGNS.IsNumberWithNonZeroPositiveValue(decodedResponseForPlayer.time_played) // discard found records lacking playtime
+	result.HasData = result.HasData and TGNS.IsNumberWithNonZeroPositiveValue(decodedResponseForPlayer.score) --// discard found records lacking score
+	result.HasData = result.HasData and TGNS.IsNumberWithNonZeroPositiveValue(decodedResponseForPlayer.time_played) --// discard found records lacking playtime
 	if result.HasData then
 		result.GetCumulativeScore = function()
 			return decodedResponseForPlayer.score


### PR DESCRIPTION
`//` is a common way of commenting code in other languages. I'm guessing these lines were commented out incorrectly due to habit. It broke some code that parses the code to generate a dependency graph and may cause other downstream issues as well.